### PR TITLE
Add subscription payment status feature with visual indicators

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'providers/expense_provider.dart';
 import 'providers/income_provider.dart';
 import 'providers/settings_provider.dart';
 import 'providers/expense_preset_provider.dart';
+import 'providers/subscription_provider.dart';
 import 'screens/home_screen.dart';
 
 void main() async {
@@ -41,6 +42,7 @@ class SavvyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (context) => IncomeProvider()),
         ChangeNotifierProvider(create: (context) => SettingsProvider()),
         ChangeNotifierProvider(create: (context) => ExpensePresetProvider()),
+        ChangeNotifierProvider(create: (context) => SubscriptionProvider()),
       ],
       child: Consumer<SettingsProvider>(
         builder: (context, settingsProvider, child) {

--- a/lib/models/subscription.dart
+++ b/lib/models/subscription.dart
@@ -1,0 +1,300 @@
+import 'package:flutter/material.dart';
+
+class Subscription {
+  final int? id;
+  final String name;
+  final double amount;
+  final String category;
+  final DateTime startDate;
+  final String billingCycle; // 'monthly', 'yearly', 'weekly', 'bi-weekly'
+  final DateTime nextBillingDate;
+  final String? description;
+  final String? icon;
+  final bool isActive;
+  final String? reminderDays; // e.g., '3,7' for 3 and 7 days before
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? lastPaidDate; // New field to track when last payment was made
+  final String? paymentStatus; // New field: 'paid', 'pending', 'overdue'
+
+  Subscription({
+    this.id,
+    required this.name,
+    required this.amount,
+    required this.category,
+    required this.startDate,
+    required this.billingCycle,
+    required this.nextBillingDate,
+    this.description,
+    this.icon,
+    this.isActive = true,
+    this.reminderDays = '3,7', // Default: remind 3 and 7 days before
+    this.createdAt,
+    this.updatedAt,
+    this.lastPaidDate,
+    this.paymentStatus = 'pending',
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'amount': amount,
+      'category': category,
+      'start_date': startDate.millisecondsSinceEpoch,
+      'billing_cycle': billingCycle,
+      'next_billing_date': nextBillingDate.millisecondsSinceEpoch,
+      'description': description,
+      'icon': icon,
+      'is_active': isActive ? 1 : 0,
+      'reminder_days': reminderDays,
+      'created_at': createdAt?.millisecondsSinceEpoch ?? DateTime.now().millisecondsSinceEpoch,
+      'updated_at': updatedAt?.millisecondsSinceEpoch ?? DateTime.now().millisecondsSinceEpoch,
+      'last_paid_date': lastPaidDate?.millisecondsSinceEpoch,
+      'payment_status': paymentStatus,
+    };
+  }
+
+  factory Subscription.fromMap(Map<String, dynamic> map) {
+    return Subscription(
+      id: map['id']?.toInt(),
+      name: map['name'] ?? '',
+      amount: map['amount']?.toDouble() ?? 0.0,
+      category: map['category'] ?? '',
+      startDate: DateTime.fromMillisecondsSinceEpoch(map['start_date'] ?? 0),
+      billingCycle: map['billing_cycle'] ?? 'monthly',
+      nextBillingDate: DateTime.fromMillisecondsSinceEpoch(map['next_billing_date'] ?? 0),
+      description: map['description'],
+      icon: map['icon'],
+      isActive: (map['is_active'] ?? 1) == 1,
+      reminderDays: map['reminder_days'],
+      createdAt: map['created_at'] != null 
+          ? DateTime.fromMillisecondsSinceEpoch(map['created_at'])
+          : null,
+      updatedAt: map['updated_at'] != null 
+          ? DateTime.fromMillisecondsSinceEpoch(map['updated_at'])
+          : null,
+      lastPaidDate: map['last_paid_date'] != null 
+          ? DateTime.fromMillisecondsSinceEpoch(map['last_paid_date'])
+          : null,
+      paymentStatus: map['payment_status'] ?? 'pending',
+    );
+  }
+
+  Subscription copyWith({
+    int? id,
+    String? name,
+    double? amount,
+    String? category,
+    DateTime? startDate,
+    String? billingCycle,
+    DateTime? nextBillingDate,
+    String? description,
+    String? icon,
+    bool? isActive,
+    String? reminderDays,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    DateTime? lastPaidDate,
+    String? paymentStatus,
+  }) {
+    return Subscription(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      amount: amount ?? this.amount,
+      category: category ?? this.category,
+      startDate: startDate ?? this.startDate,
+      billingCycle: billingCycle ?? this.billingCycle,
+      nextBillingDate: nextBillingDate ?? this.nextBillingDate,
+      description: description ?? this.description,
+      icon: icon ?? this.icon,
+      isActive: isActive ?? this.isActive,
+      reminderDays: reminderDays ?? this.reminderDays,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      lastPaidDate: lastPaidDate ?? this.lastPaidDate,
+      paymentStatus: paymentStatus ?? this.paymentStatus,
+    );
+  }
+
+  // Calculate next billing date based on current next billing date and billing cycle
+  DateTime calculateNextBillingDate() {
+    switch (billingCycle.toLowerCase()) {
+      case 'weekly':
+        return nextBillingDate.add(const Duration(days: 7));
+      case 'bi-weekly':
+        return nextBillingDate.add(const Duration(days: 14));
+      case 'monthly':
+        // Add one month to the current next billing date
+        final year = nextBillingDate.year;
+        final month = nextBillingDate.month;
+        final day = nextBillingDate.day;
+        
+        if (month == 12) {
+          return DateTime(year + 1, 1, day);
+        } else {
+          // Handle cases where the day doesn't exist in the next month (e.g., Jan 31 -> Feb 28)
+          final lastDayOfNextMonth = DateTime(year, month + 2, 0).day;
+          final adjustedDay = day > lastDayOfNextMonth ? lastDayOfNextMonth : day;
+          return DateTime(year, month + 1, adjustedDay);
+        }
+      case 'yearly':
+        return DateTime(nextBillingDate.year + 1, nextBillingDate.month, nextBillingDate.day);
+      default:
+        return nextBillingDate.add(const Duration(days: 30)); // Default to 30 days
+    }
+  }
+
+  // Get days until next billing
+  int daysUntilNextBilling() {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final billingDay = DateTime(nextBillingDate.year, nextBillingDate.month, nextBillingDate.day);
+    return billingDay.difference(today).inDays;
+  }
+
+  // Check if reminder should be shown
+  bool shouldShowReminder() {
+    if (!isActive || reminderDays == null) return false;
+    
+    final daysUntil = daysUntilNextBilling();
+    final reminderDaysList = reminderDays!.split(',').map((d) => int.tryParse(d.trim()) ?? 0).toList();
+    
+    return reminderDaysList.contains(daysUntil) || daysUntil <= 0;
+  }
+
+  // Get reminder message
+  String getReminderMessage() {
+    final daysUntil = daysUntilNextBilling();
+    
+    if (daysUntil < 0) {
+      return 'Your $name subscription was due ${-daysUntil} days ago!';
+    } else if (daysUntil == 0) {
+      return 'Your $name subscription is due today!';
+    } else if (daysUntil == 1) {
+      return 'Your $name subscription is due tomorrow!';
+    } else {
+      return 'Your $name subscription is due in $daysUntil days!';
+    }
+  }
+
+  // Check if subscription is paid for current billing cycle
+  bool isPaidForCurrentCycle() {
+    if (lastPaidDate == null) return false;
+    
+    // Get the start of current billing cycle
+    final currentCycleStart = _getCurrentCycleStartDate();
+    
+    return lastPaidDate!.isAfter(currentCycleStart.subtract(const Duration(days: 1)));
+  }
+
+  // Get the start date of the current billing cycle
+  DateTime _getCurrentCycleStartDate() {
+    final now = DateTime.now();
+    
+    switch (billingCycle.toLowerCase()) {
+      case 'weekly':
+        // Find the most recent start date that's a multiple of 7 days from startDate
+        final daysSinceStart = now.difference(startDate).inDays;
+        final cyclesPassed = (daysSinceStart / 7).floor();
+        return startDate.add(Duration(days: cyclesPassed * 7));
+        
+      case 'bi-weekly':
+        // Find the most recent start date that's a multiple of 14 days from startDate
+        final daysSinceStart = now.difference(startDate).inDays;
+        final cyclesPassed = (daysSinceStart / 14).floor();
+        return startDate.add(Duration(days: cyclesPassed * 14));
+        
+      case 'monthly':
+        // Find the most recent monthly cycle start
+        if (now.day >= startDate.day) {
+          return DateTime(now.year, now.month, startDate.day);
+        } else {
+          if (now.month == 1) {
+            return DateTime(now.year - 1, 12, startDate.day);
+          } else {
+            return DateTime(now.year, now.month - 1, startDate.day);
+          }
+        }
+        
+      case 'yearly':
+        // Find the most recent yearly cycle start
+        if (now.month > startDate.month || 
+            (now.month == startDate.month && now.day >= startDate.day)) {
+          return DateTime(now.year, startDate.month, startDate.day);
+        } else {
+          return DateTime(now.year - 1, startDate.month, startDate.day);
+        }
+        
+      default:
+        return startDate;
+    }
+  }
+
+  // Get payment status with more detailed information
+  String getDetailedPaymentStatus() {
+    if (isPaidForCurrentCycle()) {
+      return 'paid';
+    }
+    
+    final daysUntil = daysUntilNextBilling();
+    if (daysUntil < 0) {
+      return 'overdue';
+    } else if (daysUntil <= 7) {
+      return 'due_soon';
+    } else {
+      return 'pending';
+    }
+  }
+
+  // Get status color for UI
+  Color getStatusColor() {
+    switch (getDetailedPaymentStatus()) {
+      case 'paid':
+        return const Color(0xFF4CAF50); // Green
+      case 'overdue':
+        return const Color(0xFFD32F2F); // Red
+      case 'due_soon':
+        return const Color(0xFFFF9800); // Orange
+      default:
+        return const Color(0xFF757575); // Gray
+    }
+  }
+
+  // Mark as paid for current cycle
+  Subscription markAsPaid() {
+    return copyWith(
+      lastPaidDate: DateTime.now(),
+      paymentStatus: 'paid',
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  String toString() {
+    return 'Subscription(id: $id, name: $name, amount: $amount, nextBillingDate: $nextBillingDate)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    
+    return other is Subscription &&
+        other.id == id &&
+        other.name == name &&
+        other.amount == amount &&
+        other.category == category &&
+        other.startDate == startDate &&
+        other.billingCycle == billingCycle;
+  }
+
+  @override
+  int get hashCode {
+    return id.hashCode ^
+        name.hashCode ^
+        amount.hashCode ^
+        category.hashCode ^
+        startDate.hashCode ^
+        billingCycle.hashCode;
+  }
+}

--- a/lib/providers/subscription_provider.dart
+++ b/lib/providers/subscription_provider.dart
@@ -1,0 +1,285 @@
+import 'package:flutter/foundation.dart';
+import '../models/subscription.dart';
+import '../services/database_helper.dart';
+
+class SubscriptionProvider extends ChangeNotifier {
+  List<Subscription> _subscriptions = [];
+  bool _isLoading = false;
+  List<Subscription> _upcomingReminders = [];
+
+  List<Subscription> get subscriptions => _subscriptions;
+  List<Subscription> get activeSubscriptions => _subscriptions.where((s) => s.isActive).toList();
+  List<Subscription> get upcomingReminders => _upcomingReminders;
+  bool get isLoading => _isLoading;
+
+  final DatabaseHelper _databaseHelper = DatabaseHelper();
+
+  SubscriptionProvider() {
+    loadSubscriptions();
+  }
+
+  // Calculate total monthly subscription cost
+  double get totalMonthlyCost {
+    double total = 0.0;
+    for (final subscription in activeSubscriptions) {
+      switch (subscription.billingCycle.toLowerCase()) {
+        case 'weekly':
+          total += subscription.amount * 4.33; // Approximate weeks per month
+          break;
+        case 'bi-weekly':
+          total += subscription.amount * 2.17; // Approximate bi-weeks per month
+          break;
+        case 'monthly':
+          total += subscription.amount;
+          break;
+        case 'yearly':
+          total += subscription.amount / 12;
+          break;
+      }
+    }
+    return total;
+  }
+
+  // Calculate total yearly subscription cost
+  double get totalYearlyCost {
+    double total = 0.0;
+    for (final subscription in activeSubscriptions) {
+      switch (subscription.billingCycle.toLowerCase()) {
+        case 'weekly':
+          total += subscription.amount * 52;
+          break;
+        case 'bi-weekly':
+          total += subscription.amount * 26;
+          break;
+        case 'monthly':
+          total += subscription.amount * 12;
+          break;
+        case 'yearly':
+          total += subscription.amount;
+          break;
+      }
+    }
+    return total;
+  }
+
+  Future<void> loadSubscriptions() async {
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      _subscriptions = await _databaseHelper.getSubscriptions();
+      _updateUpcomingReminders();
+      print('Loaded ${_subscriptions.length} subscriptions');
+    } catch (e) {
+      print('Error loading subscriptions: $e');
+    }
+
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  Future<void> addSubscription(Subscription subscription) async {
+    try {
+      final newSubscription = await _databaseHelper.insertSubscription(subscription);
+      _subscriptions.add(newSubscription);
+      _subscriptions.sort((a, b) => a.nextBillingDate.compareTo(b.nextBillingDate));
+      _updateUpcomingReminders();
+      print('Added subscription: ${newSubscription.name}');
+      notifyListeners();
+    } catch (e) {
+      print('Error adding subscription: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> updateSubscription(Subscription subscription) async {
+    try {
+      await _databaseHelper.updateSubscription(subscription);
+      final index = _subscriptions.indexWhere((s) => s.id == subscription.id);
+      if (index != -1) {
+        _subscriptions[index] = subscription;
+        _subscriptions.sort((a, b) => a.nextBillingDate.compareTo(b.nextBillingDate));
+        _updateUpcomingReminders();
+        print('Updated subscription: ${subscription.name}');
+        notifyListeners();
+      }
+    } catch (e) {
+      print('Error updating subscription: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> deleteSubscription(int id) async {
+    try {
+      await _databaseHelper.deleteSubscription(id);
+      _subscriptions.removeWhere((s) => s.id == id);
+      _updateUpcomingReminders();
+      print('Deleted subscription with ID: $id');
+      notifyListeners();
+    } catch (e) {
+      print('Error deleting subscription: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> toggleSubscriptionStatus(int id) async {
+    try {
+      final subscription = _subscriptions.firstWhere((s) => s.id == id);
+      final updatedSubscription = subscription.copyWith(
+        isActive: !subscription.isActive,
+        updatedAt: DateTime.now(),
+      );
+      await updateSubscription(updatedSubscription);
+    } catch (e) {
+      print('Error toggling subscription status: $e');
+      rethrow;
+    }
+  }
+
+  // Mark subscription as paid and update next billing date
+  Future<void> markAsPaid(int id) async {
+    try {
+      final subscription = _subscriptions.firstWhere((s) => s.id == id);
+      final newNextBillingDate = subscription.calculateNextBillingDate();
+      
+      final updatedSubscription = subscription.copyWith(
+        nextBillingDate: newNextBillingDate,
+        updatedAt: DateTime.now(),
+      );
+      
+      await updateSubscription(updatedSubscription);
+      
+      // Optionally, automatically create an expense entry for this payment
+      // You can uncomment this if you want automatic expense tracking
+      /*
+      final expenseProvider = Provider.of<ExpenseProvider>(context, listen: false);
+      final expense = Expense(
+        title: subscription.name,
+        amount: subscription.amount,
+        category: subscription.category,
+        date: DateTime.now(),
+        description: 'Subscription payment - ${subscription.billingCycle}',
+      );
+      await expenseProvider.addExpense(expense);
+      */
+      
+    } catch (e) {
+      print('Error marking subscription as paid: $e');
+      rethrow;
+    }
+  }
+
+  // Get subscriptions due within specified days
+  List<Subscription> getSubscriptionsDueWithin(int days) {
+    final cutoffDate = DateTime.now().add(Duration(days: days));
+    return activeSubscriptions.where((subscription) {
+      return subscription.nextBillingDate.isBefore(cutoffDate) ||
+             subscription.nextBillingDate.isAtSameMomentAs(cutoffDate);
+    }).toList();
+  }
+
+  // Get overdue subscriptions
+  List<Subscription> get overdueSubscriptions {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    
+    return activeSubscriptions.where((subscription) {
+      final billingDay = DateTime(
+        subscription.nextBillingDate.year,
+        subscription.nextBillingDate.month,
+        subscription.nextBillingDate.day,
+      );
+      return billingDay.isBefore(today);
+    }).toList();
+  }
+
+  void _updateUpcomingReminders() {
+    _upcomingReminders = activeSubscriptions.where((subscription) {
+      return subscription.shouldShowReminder();
+    }).toList();
+    
+    // Sort by next billing date
+    _upcomingReminders.sort((a, b) => a.nextBillingDate.compareTo(b.nextBillingDate));
+  }
+
+  Subscription? getSubscriptionById(int id) {
+    try {
+      return _subscriptions.firstWhere((s) => s.id == id);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  List<Subscription> getSubscriptionsByCategory(String category) {
+    return _subscriptions.where((s) => s.category == category).toList();
+  }
+
+  // Get subscription statistics
+  Map<String, int> get subscriptionStats {
+    final stats = <String, int>{};
+    for (final subscription in activeSubscriptions) {
+      stats[subscription.category] = (stats[subscription.category] ?? 0) + 1;
+    }
+    return stats;
+  }
+
+  // Force refresh
+  void forceRefresh() {
+    loadSubscriptions();
+  }
+
+  // Mark subscription as paid for current cycle
+  Future<void> markSubscriptionAsPaid(int subscriptionId) async {
+    try {
+      final subscription = getSubscriptionById(subscriptionId);
+      if (subscription == null) return;
+
+      final paidSubscription = subscription.markAsPaid();
+      await _databaseHelper.updateSubscription(paidSubscription);
+      
+      final index = _subscriptions.indexWhere((s) => s.id == subscriptionId);
+      if (index != -1) {
+        _subscriptions[index] = paidSubscription;
+        print('Marked subscription as paid: ${paidSubscription.name}');
+        notifyListeners();
+      }
+    } catch (e) {
+      print('Error marking subscription as paid: $e');
+      rethrow;
+    }
+  }
+
+  // Update all subscriptions - check for billing cycles that have passed
+  Future<void> updateBillingCycles() async {
+    final now = DateTime.now();
+    bool hasUpdates = false;
+    
+    for (final subscription in List.from(_subscriptions)) {
+      if (subscription.isActive && subscription.nextBillingDate.isBefore(now)) {
+        // Auto-update the next billing date if it has passed
+        final newNextBillingDate = subscription.calculateNextBillingDate();
+        final updatedSubscription = subscription.copyWith(
+          nextBillingDate: newNextBillingDate,
+          updatedAt: DateTime.now(),
+        );
+        
+        try {
+          await _databaseHelper.updateSubscription(updatedSubscription);
+          final index = _subscriptions.indexWhere((s) => s.id == subscription.id);
+          if (index != -1) {
+            _subscriptions[index] = updatedSubscription;
+            hasUpdates = true;
+          }
+        } catch (e) {
+          print('Error updating billing cycle for ${subscription.name}: $e');
+        }
+      }
+    }
+    
+    if (hasUpdates) {
+      _subscriptions.sort((a, b) => a.nextBillingDate.compareTo(b.nextBillingDate));
+      _updateUpcomingReminders();
+      notifyListeners();
+    }
+  }
+}

--- a/lib/screens/add_subscription_screen.dart
+++ b/lib/screens/add_subscription_screen.dart
@@ -1,0 +1,478 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/subscription_provider.dart';
+import '../providers/settings_provider.dart';
+import '../models/subscription.dart';
+
+class AddSubscriptionScreen extends StatefulWidget {
+  final Subscription? subscription;
+
+  const AddSubscriptionScreen({super.key, this.subscription});
+
+  @override
+  State<AddSubscriptionScreen> createState() => _AddSubscriptionScreenState();
+}
+
+class _AddSubscriptionScreenState extends State<AddSubscriptionScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _amountController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  
+  String _selectedCategory = 'Entertainment';
+  String _selectedIcon = 'subscriptions';
+  String _selectedBillingCycle = 'monthly';
+  DateTime _startDate = DateTime.now();
+  DateTime _nextBillingDate = DateTime.now().add(const Duration(days: 30));
+  List<String> _selectedReminderDays = ['3', '7'];
+  bool _isLoading = false;
+
+  final List<String> _categories = [
+    'Entertainment', 'Utilities', 'Health & Fitness', 'Communication', 
+    'Software', 'News & Media', 'Food & Delivery', 'Transportation', 'Other'
+  ];
+
+  final List<String> _billingCycles = [
+    'weekly', 'bi-weekly', 'monthly', 'yearly'
+  ];
+
+  final List<Map<String, dynamic>> _icons = [
+    {'name': 'subscriptions', 'icon': Icons.subscriptions, 'label': 'General'},
+    {'name': 'netflix', 'icon': Icons.movie, 'label': 'Streaming'},
+    {'name': 'spotify', 'icon': Icons.music_note, 'label': 'Music'},
+    {'name': 'gym', 'icon': Icons.fitness_center, 'label': 'Fitness'},
+    {'name': 'phone', 'icon': Icons.phone, 'label': 'Phone'},
+    {'name': 'internet', 'icon': Icons.wifi, 'label': 'Internet'},
+    {'name': 'cloud', 'icon': Icons.cloud, 'label': 'Cloud'},
+    {'name': 'gaming', 'icon': Icons.games, 'label': 'Gaming'},
+    {'name': 'news', 'icon': Icons.newspaper, 'label': 'News'},
+    {'name': 'food', 'icon': Icons.restaurant, 'label': 'Food'},
+  ];
+
+  final List<Map<String, dynamic>> _reminderOptions = [
+    {'value': '1', 'label': '1 day before'},
+    {'value': '3', 'label': '3 days before'},
+    {'value': '7', 'label': '1 week before'},
+    {'value': '14', 'label': '2 weeks before'},
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    
+    if (widget.subscription != null) {
+      final sub = widget.subscription!;
+      _nameController.text = sub.name;
+      _amountController.text = sub.amount.toString();
+      _descriptionController.text = sub.description ?? '';
+      _selectedCategory = sub.category;
+      _selectedIcon = sub.icon ?? 'subscriptions';
+      _selectedBillingCycle = sub.billingCycle;
+      _startDate = sub.startDate;
+      _nextBillingDate = sub.nextBillingDate;
+      _selectedReminderDays = sub.reminderDays?.split(',').map((e) => e.trim()).toList() ?? ['3', '7'];
+    } else {
+      _updateNextBillingDate();
+    }
+  }
+
+  void _updateNextBillingDate() {
+    switch (_selectedBillingCycle) {
+      case 'weekly':
+        _nextBillingDate = _startDate.add(const Duration(days: 7));
+        break;
+      case 'bi-weekly':
+        _nextBillingDate = _startDate.add(const Duration(days: 14));
+        break;
+      case 'monthly':
+        _nextBillingDate = DateTime(_startDate.year, _startDate.month + 1, _startDate.day);
+        break;
+      case 'yearly':
+        _nextBillingDate = DateTime(_startDate.year + 1, _startDate.month, _startDate.day);
+        break;
+    }
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _amountController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEditing = widget.subscription != null;
+    
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditing ? 'Edit Subscription' : 'Add Subscription'),
+        actions: [
+          if (_isLoading)
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.all(16.0),
+                child: SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              ),
+            )
+          else
+            TextButton(
+              onPressed: _saveSubscription,
+              child: Text(isEditing ? 'Update' : 'Save'),
+            ),
+        ],
+      ),
+      body: Consumer<SettingsProvider>(
+        builder: (context, settingsProvider, child) {
+          return Form(
+            key: _formKey,
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Icon selection
+                  Text(
+                    'Icon',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Container(
+                    height: 80,
+                    child: ListView.builder(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: _icons.length,
+                      itemBuilder: (context, index) {
+                        final iconData = _icons[index];
+                        final isSelected = _selectedIcon == iconData['name'];
+                        
+                        return GestureDetector(
+                          onTap: () {
+                            setState(() {
+                              _selectedIcon = iconData['name'];
+                            });
+                          },
+                          child: Container(
+                            width: 60,
+                            margin: const EdgeInsets.only(right: 12),
+                            decoration: BoxDecoration(
+                              color: isSelected 
+                                  ? Theme.of(context).colorScheme.primaryContainer
+                                  : Theme.of(context).colorScheme.surfaceVariant,
+                              borderRadius: BorderRadius.circular(12),
+                              border: isSelected
+                                  ? Border.all(
+                                      color: Theme.of(context).colorScheme.primary,
+                                      width: 2,
+                                    )
+                                  : null,
+                            ),
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Icon(
+                                  iconData['icon'],
+                                  color: isSelected
+                                      ? Theme.of(context).colorScheme.onPrimaryContainer
+                                      : Theme.of(context).colorScheme.onSurfaceVariant,
+                                  size: 24,
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  iconData['label'],
+                                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: isSelected
+                                        ? Theme.of(context).colorScheme.onPrimaryContainer
+                                        : Theme.of(context).colorScheme.onSurfaceVariant,
+                                    fontSize: 10,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  
+                  const SizedBox(height: 24),
+
+                  // Subscription name
+                  TextFormField(
+                    controller: _nameController,
+                    decoration: const InputDecoration(
+                      labelText: 'Subscription Name',
+                      hintText: 'e.g., Netflix, Spotify',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Please enter a subscription name';
+                      }
+                      return null;
+                    },
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Amount
+                  TextFormField(
+                    controller: _amountController,
+                    decoration: InputDecoration(
+                      labelText: 'Amount',
+                      hintText: '0.00',
+                      prefixText: '${settingsProvider.currencySymbol} ',
+                      border: OutlineInputBorder(),
+                    ),
+                    keyboardType: TextInputType.number,
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Please enter an amount';
+                      }
+                      if (double.tryParse(value) == null) {
+                        return 'Please enter a valid number';
+                      }
+                      if (double.parse(value) <= 0) {
+                        return 'Amount must be greater than 0';
+                      }
+                      return null;
+                    },
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Category
+                  DropdownButtonFormField<String>(
+                    value: _selectedCategory,
+                    decoration: const InputDecoration(
+                      labelText: 'Category',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: _categories.map((category) {
+                      return DropdownMenuItem(
+                        value: category,
+                        child: Text(category),
+                      );
+                    }).toList(),
+                    onChanged: (value) {
+                      setState(() {
+                        _selectedCategory = value!;
+                      });
+                    },
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Billing cycle
+                  DropdownButtonFormField<String>(
+                    value: _selectedBillingCycle,
+                    decoration: const InputDecoration(
+                      labelText: 'Billing Cycle',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: _billingCycles.map((cycle) {
+                      return DropdownMenuItem(
+                        value: cycle,
+                        child: Text(cycle.replaceFirst(cycle[0], cycle[0].toUpperCase())),
+                      );
+                    }).toList(),
+                    onChanged: (value) {
+                      setState(() {
+                        _selectedBillingCycle = value!;
+                        _updateNextBillingDate();
+                      });
+                    },
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Start date
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Start Date'),
+                    subtitle: Text('${_startDate.day}/${_startDate.month}/${_startDate.year}'),
+                    trailing: const Icon(Icons.calendar_today),
+                    onTap: () async {
+                      final date = await showDatePicker(
+                        context: context,
+                        initialDate: _startDate,
+                        firstDate: DateTime(2020),
+                        lastDate: DateTime.now().add(const Duration(days: 365)),
+                      );
+                      if (date != null) {
+                        setState(() {
+                          _startDate = date;
+                          _updateNextBillingDate();
+                        });
+                      }
+                    },
+                  ),
+
+                  const Divider(),
+
+                  // Next billing date (calculated)
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Next Billing Date'),
+                    subtitle: Text('${_nextBillingDate.day}/${_nextBillingDate.month}/${_nextBillingDate.year}'),
+                    trailing: const Icon(Icons.event_note),
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Reminder settings
+                  Text(
+                    'Reminder Settings',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    children: _reminderOptions.map((option) {
+                      final isSelected = _selectedReminderDays.contains(option['value']);
+                      return FilterChip(
+                        label: Text(option['label']),
+                        selected: isSelected,
+                        onSelected: (selected) {
+                          setState(() {
+                            if (selected) {
+                              _selectedReminderDays.add(option['value']);
+                            } else {
+                              _selectedReminderDays.remove(option['value']);
+                            }
+                          });
+                        },
+                      );
+                    }).toList(),
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Description
+                  TextFormField(
+                    controller: _descriptionController,
+                    decoration: const InputDecoration(
+                      labelText: 'Description (Optional)',
+                      hintText: 'Additional notes about this subscription',
+                      border: OutlineInputBorder(),
+                    ),
+                    maxLines: 3,
+                  ),
+
+                  const SizedBox(height: 32),
+
+                  // Save button
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: _isLoading ? null : _saveSubscription,
+                      child: _isLoading
+                          ? const Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                SizedBox(
+                                  width: 20,
+                                  height: 20,
+                                  child: CircularProgressIndicator(strokeWidth: 2),
+                                ),
+                                SizedBox(width: 12),
+                                Text('Saving...'),
+                              ],
+                            )
+                          : Text(isEditing ? 'Update Subscription' : 'Add Subscription'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _saveSubscription() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    if (_selectedReminderDays.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Please select at least one reminder option'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final subscription = Subscription(
+        id: widget.subscription?.id,
+        name: _nameController.text.trim(),
+        amount: double.parse(_amountController.text),
+        category: _selectedCategory,
+        startDate: _startDate,
+        billingCycle: _selectedBillingCycle,
+        nextBillingDate: _nextBillingDate,
+        description: _descriptionController.text.trim().isEmpty 
+            ? null 
+            : _descriptionController.text.trim(),
+        icon: _selectedIcon,
+        reminderDays: _selectedReminderDays.join(','),
+      );
+
+      final subscriptionProvider = Provider.of<SubscriptionProvider>(context, listen: false);
+
+      if (widget.subscription != null) {
+        // Update existing subscription
+        await subscriptionProvider.updateSubscription(subscription);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Updated "${subscription.name}"')),
+          );
+        }
+      } else {
+        // Create new subscription
+        await subscriptionProvider.addSubscription(subscription);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Added "${subscription.name}"')),
+          );
+        }
+      }
+
+      if (mounted) {
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+      });
+      
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Error saving subscription. Please try again.'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,12 +9,14 @@ import '../widgets/income_card.dart';
 import '../widgets/category_chart.dart';
 import '../widgets/summary_card.dart';
 import '../widgets/budget_status_card.dart';
+import '../widgets/subscription_reminder_widget.dart';
 import '../widgets/preset_quick_access_widget.dart';
 import 'add_expense_screen.dart';
 import 'add_income_screen.dart';
 import 'expense_list_screen.dart';
 import 'analytics_screen.dart';
 import 'settings_screen.dart';
+import 'subscription_management_screen.dart';
 import 'preset_management_screen.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -176,6 +178,15 @@ class _HomeTab extends StatelessWidget {
             tooltip: 'Expense Presets',
           ),
           IconButton(
+            icon: const Icon(Icons.subscriptions),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (context) => const SubscriptionManagementScreen()),
+              );
+            },
+            tooltip: 'Subscriptions',
+          ),
+          IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {
               Navigator.of(context).push(
@@ -289,6 +300,9 @@ class _HomeTab extends StatelessWidget {
 
                     // Budget Status Card
                     const BudgetStatusCard(),
+                    
+                    // Subscription reminders
+                    const SubscriptionReminderWidget(),
 
                     const SizedBox(height: 8),
 

--- a/lib/screens/subscription_management_screen.dart
+++ b/lib/screens/subscription_management_screen.dart
@@ -1,0 +1,679 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+import '../providers/subscription_provider.dart';
+import '../providers/settings_provider.dart';
+import '../models/subscription.dart';
+import 'add_subscription_screen.dart';
+
+class SubscriptionManagementScreen extends StatelessWidget {
+  const SubscriptionManagementScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Subscriptions'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const AddSubscriptionScreen(),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+      body: Consumer2<SubscriptionProvider, SettingsProvider>(
+        builder: (context, subscriptionProvider, settingsProvider, child) {
+          if (subscriptionProvider.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final subscriptions = subscriptionProvider.subscriptions;
+
+          if (subscriptions.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.subscriptions,
+                    size: 64,
+                    color: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'No subscriptions yet',
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Track your recurring subscriptions and get reminders',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton.icon(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const AddSubscriptionScreen(),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.add),
+                    label: const Text('Add First Subscription'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return Column(
+            children: [
+              // Summary Card
+              Card(
+                margin: const EdgeInsets.all(16),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Subscription Summary',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: _buildSummaryItem(
+                              context,
+                              'Monthly',
+                              '${settingsProvider.currencySymbol}${subscriptionProvider.totalMonthlyCost.toStringAsFixed(2)}',
+                              Icons.calendar_month,
+                            ),
+                          ),
+                          Expanded(
+                            child: _buildSummaryItem(
+                              context,
+                              'Yearly',
+                              '${settingsProvider.currencySymbol}${subscriptionProvider.totalYearlyCost.toStringAsFixed(2)}',
+                              Icons.calendar_today,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: _buildSummaryItem(
+                              context,
+                              'Active',
+                              '${subscriptionProvider.activeSubscriptions.length}',
+                              Icons.check_circle,
+                            ),
+                          ),
+                          Expanded(
+                            child: _buildSummaryItem(
+                              context,
+                              'Due Soon',
+                              '${subscriptionProvider.upcomingReminders.length}',
+                              Icons.notification_important,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+
+              // Reminders Section
+              if (subscriptionProvider.upcomingReminders.isNotEmpty) ...[
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.notification_important,
+                        color: Colors.orange,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Upcoming Bills',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: Colors.orange,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 8),
+                ...subscriptionProvider.upcomingReminders.map((subscription) =>
+                  _buildReminderCard(context, subscription, subscriptionProvider, settingsProvider)
+                ).toList(),
+                const SizedBox(height: 16),
+              ],
+
+              // All Subscriptions
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  children: [
+                    Text(
+                      'All Subscriptions',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 8),
+
+              // Subscription List
+              Expanded(
+                child: ListView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  itemCount: subscriptions.length,
+                  itemBuilder: (context, index) {
+                    final subscription = subscriptions[index];
+                    return _buildSubscriptionCard(context, subscription, subscriptionProvider, settingsProvider);
+                  },
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSummaryItem(BuildContext context, String label, String value, IconData icon) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        children: [
+          Icon(icon, size: 20, color: Theme.of(context).colorScheme.primary),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildReminderCard(BuildContext context, Subscription subscription, 
+      SubscriptionProvider subscriptionProvider, SettingsProvider settingsProvider) {
+    
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      color: Colors.orange.withOpacity(0.1),
+      child: ListTile(
+        leading: Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: Colors.orange.withOpacity(0.2),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Icon(
+            _getIconData(subscription.icon ?? 'subscriptions'),
+            color: Colors.orange,
+            size: 20,
+          ),
+        ),
+        title: Text(
+          subscription.name,
+          style: const TextStyle(fontWeight: FontWeight.w600),
+        ),
+        subtitle: Text(subscription.getReminderMessage()),
+        trailing: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              '${settingsProvider.currencySymbol}${subscription.amount.toStringAsFixed(2)}',
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.orange,
+              ),
+            ),
+            Text(
+              subscription.billingCycle,
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+              ),
+            ),
+          ],
+        ),
+        onTap: () {
+          _showSubscriptionActions(context, subscription, subscriptionProvider, settingsProvider);
+        },
+      ),
+    );
+  }
+
+  Widget _buildSubscriptionCard(BuildContext context, Subscription subscription, 
+      SubscriptionProvider subscriptionProvider, SettingsProvider settingsProvider) {
+    final isOverdue = subscription.daysUntilNextBilling() < 0;
+    final isDueSoon = subscription.shouldShowReminder() && subscription.daysUntilNextBilling() >= 0;
+    final isPaid = subscription.isPaidForCurrentCycle();
+    final statusColor = subscription.getStatusColor();
+    
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      elevation: 2,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          border: isPaid ? Border.all(color: statusColor, width: 2) : null,
+        ),
+        child: ListTile(
+          leading: Stack(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: subscription.isActive 
+                      ? Theme.of(context).colorScheme.primaryContainer
+                      : Theme.of(context).colorScheme.surfaceVariant,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  _getIconData(subscription.icon ?? 'subscriptions'),
+                  color: subscription.isActive 
+                      ? Theme.of(context).colorScheme.onPrimaryContainer
+                      : Theme.of(context).colorScheme.onSurfaceVariant,
+                  size: 20,
+                ),
+              ),
+              // Payment status indicator
+              if (isPaid)
+                Positioned(
+                  top: -2,
+                  right: -2,
+                  child: Container(
+                    width: 16,
+                    height: 16,
+                    decoration: BoxDecoration(
+                      color: statusColor,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: Colors.white, width: 1),
+                    ),
+                    child: const Icon(
+                      Icons.check,
+                      color: Colors.white,
+                      size: 10,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          title: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  subscription.name,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    decoration: subscription.isActive ? null : TextDecoration.lineThrough,
+                  ),
+                ),
+              ),
+              // Status badges
+              if (isPaid)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: statusColor,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const Text(
+                    'PAID',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                )
+              else if (isOverdue)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: Colors.red,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const Text(
+                    'OVERDUE',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                )
+              else if (isDueSoon)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: Colors.orange,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const Text(
+                    'DUE SOON',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('${subscription.category} • ${subscription.billingCycle}'),
+              const SizedBox(height: 2),
+              Text(
+                'Next: ${DateFormat('MMM dd, yyyy').format(subscription.nextBillingDate)}',
+                style: TextStyle(
+                  color: isPaid 
+                      ? statusColor 
+                      : (isOverdue ? Colors.red : (isDueSoon ? Colors.orange : null)),
+                  fontWeight: isPaid || isOverdue || isDueSoon ? FontWeight.w500 : null,
+                ),
+              ),
+              if (isPaid) ...[
+                const SizedBox(height: 2),
+                Text(
+                  'Paid on ${DateFormat('MMM dd').format(subscription.lastPaidDate!)}',
+                  style: TextStyle(
+                    color: statusColor,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ],
+          ),
+          trailing: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                '${settingsProvider.currencySymbol}${subscription.amount.toStringAsFixed(2)}',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: isPaid 
+                      ? statusColor 
+                      : (subscription.isActive ? Theme.of(context).colorScheme.primary : null),
+                ),
+              ),
+              if (!subscription.isActive)
+                Text(
+                  'Inactive',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5),
+                  ),
+                ),
+            ],
+          ),
+          onTap: () {
+            _showSubscriptionActions(context, subscription, subscriptionProvider, settingsProvider);
+          },
+        ),
+      ),
+    );
+  }
+
+  void _showSubscriptionActions(BuildContext context, Subscription subscription, 
+      SubscriptionProvider subscriptionProvider, SettingsProvider settingsProvider) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => Container(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              subscription.name,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Next billing: ${DateFormat('MMM dd, yyyy').format(subscription.nextBillingDate)}',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+              ),
+            ),
+            Text(
+              '${settingsProvider.currencySymbol}${subscription.amount.toStringAsFixed(2)}',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                // Conditional "Mark as Paid" or "Already Paid" button
+                if (!subscription.isPaidForCurrentCycle())
+                  ElevatedButton.icon(
+                    onPressed: () async {
+                      Navigator.pop(context);
+                      try {
+                        await subscriptionProvider.markSubscriptionAsPaid(subscription.id!);
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text('Marked "${subscription.name}" as paid'),
+                              backgroundColor: Colors.green,
+                            ),
+                          );
+                        }
+                      } catch (e) {
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Error marking as paid'),
+                              backgroundColor: Colors.red,
+                            ),
+                          );
+                        }
+                      }
+                    },
+                    icon: const Icon(Icons.payment),
+                    label: const Text('Mark as Paid'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green,
+                      foregroundColor: Colors.white,
+                    ),
+                  )
+                else
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    decoration: BoxDecoration(
+                      color: Colors.green.withOpacity(0.1),
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: Colors.green.withOpacity(0.3)),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.check_circle, color: Colors.green, size: 18),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Paid for this cycle',
+                          style: TextStyle(
+                            color: Colors.green[700],
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                OutlinedButton.icon(
+                  onPressed: () {
+                    Navigator.pop(context);
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => AddSubscriptionScreen(subscription: subscription),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.edit),
+                  label: const Text('Edit'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: TextButton.icon(
+                    onPressed: () async {
+                      Navigator.pop(context);
+                      try {
+                        await subscriptionProvider.toggleSubscriptionStatus(subscription.id!);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(subscription.isActive 
+                                ? 'Deactivated "${subscription.name}"'
+                                : 'Activated "${subscription.name}"'),
+                          ),
+                        );
+                      } catch (e) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('Error updating subscription'),
+                            backgroundColor: Colors.red,
+                          ),
+                        );
+                      }
+                    },
+                    icon: Icon(subscription.isActive ? Icons.pause : Icons.play_arrow),
+                    label: Text(subscription.isActive ? 'Deactivate' : 'Activate'),
+                  ),
+                ),
+                Expanded(
+                  child: TextButton.icon(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      _showDeleteConfirmation(context, subscription, subscriptionProvider);
+                    },
+                    icon: const Icon(Icons.delete, color: Colors.red),
+                    label: const Text('Delete', style: TextStyle(color: Colors.red)),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showDeleteConfirmation(BuildContext context, Subscription subscription, SubscriptionProvider subscriptionProvider) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Subscription'),
+        content: Text('Are you sure you want to delete "${subscription.name}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () async {
+              try {
+                await subscriptionProvider.deleteSubscription(subscription.id!);
+                if (context.mounted) {
+                  Navigator.pop(context);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Deleted "${subscription.name}"')),
+                  );
+                }
+              } catch (e) {
+                if (context.mounted) {
+                  Navigator.pop(context);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Error deleting subscription')),
+                  );
+                }
+              }
+            },
+            child: const Text('Delete', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  IconData _getIconData(String iconName) {
+    switch (iconName.toLowerCase()) {
+      case 'netflix':
+        return Icons.movie;
+      case 'spotify':
+        return Icons.music_note;
+      case 'gym':
+        return Icons.fitness_center;
+      case 'phone':
+        return Icons.phone;
+      case 'internet':
+        return Icons.wifi;
+      case 'cloud':
+        return Icons.cloud;
+      case 'gaming':
+        return Icons.games;
+      case 'news':
+        return Icons.newspaper;
+      case 'food':
+        return Icons.restaurant;
+      case 'transport':
+        return Icons.directions_car;
+      default:
+        return Icons.subscriptions;
+    }
+  }
+}

--- a/lib/widgets/subscription_reminder_widget.dart
+++ b/lib/widgets/subscription_reminder_widget.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+import '../providers/subscription_provider.dart';
+import '../providers/settings_provider.dart';
+import '../models/subscription.dart';
+import '../screens/subscription_management_screen.dart';
+
+class SubscriptionReminderWidget extends StatelessWidget {
+  const SubscriptionReminderWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer2<SubscriptionProvider, SettingsProvider>(
+      builder: (context, subscriptionProvider, settingsProvider, child) {
+        if (subscriptionProvider.isLoading) {
+          return const SizedBox.shrink();
+        }
+
+        final upcomingReminders = subscriptionProvider.upcomingReminders;
+        final overdueSubscriptions = subscriptionProvider.overdueSubscriptions;
+
+        // Show nothing if no reminders or overdue subscriptions
+        if (upcomingReminders.isEmpty && overdueSubscriptions.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        return Card(
+          margin: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.notification_important,
+                      color: overdueSubscriptions.isNotEmpty ? Colors.red : Colors.orange,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      overdueSubscriptions.isNotEmpty ? 'Overdue Subscriptions' : 'Upcoming Bills',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: overdueSubscriptions.isNotEmpty ? Colors.red : Colors.orange,
+                      ),
+                    ),
+                    const Spacer(),
+                    TextButton(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const SubscriptionManagementScreen(),
+                          ),
+                        );
+                      },
+                      child: const Text('View All'),
+                    ),
+                  ],
+                ),
+              ),
+              
+              // Show overdue subscriptions first
+              ...overdueSubscriptions.take(2).map((subscription) =>
+                _buildSubscriptionItem(context, subscription, settingsProvider, isOverdue: true)
+              ).toList(),
+              
+              // Then show upcoming reminders
+              ...upcomingReminders.take(3 - overdueSubscriptions.length).map((subscription) =>
+                _buildSubscriptionItem(context, subscription, settingsProvider)
+              ).toList(),
+              
+              if (upcomingReminders.length + overdueSubscriptions.length > 3)
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Center(
+                    child: Text(
+                      '+${upcomingReminders.length + overdueSubscriptions.length - 3} more',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSubscriptionItem(BuildContext context, Subscription subscription, 
+      SettingsProvider settingsProvider, {bool isOverdue = false}) {
+    final daysUntil = subscription.daysUntilNextBilling();
+    String subtitle;
+    
+    if (isOverdue) {
+      final daysPast = -daysUntil;
+      subtitle = daysPast == 1 ? 'Due yesterday' : 'Due $daysPast days ago';
+    } else if (daysUntil == 0) {
+      subtitle = 'Due today';
+    } else if (daysUntil == 1) {
+      subtitle = 'Due tomorrow';
+    } else {
+      subtitle = 'Due in $daysUntil days';
+    }
+
+    return ListTile(
+      leading: Container(
+        width: 40,
+        height: 40,
+        decoration: BoxDecoration(
+          color: isOverdue 
+              ? Colors.red.withOpacity(0.2)
+              : Colors.orange.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(
+          _getIconData(subscription.icon ?? 'subscriptions'),
+          color: isOverdue ? Colors.red : Colors.orange,
+          size: 20,
+        ),
+      ),
+      title: Text(
+        subscription.name,
+        style: const TextStyle(fontWeight: FontWeight.w600),
+      ),
+      subtitle: Row(
+        children: [
+          Expanded(child: Text(subtitle)),
+          if (isOverdue)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.red,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Text(
+                'OVERDUE',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+        ],
+      ),
+      trailing: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(
+            '${settingsProvider.currencySymbol}${subscription.amount.toStringAsFixed(2)}',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: isOverdue ? Colors.red : Colors.orange,
+            ),
+          ),
+          Text(
+            DateFormat('MMM dd').format(subscription.nextBillingDate),
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+            ),
+          ),
+        ],
+      ),
+      onTap: () {
+        _showQuickActions(context, subscription, settingsProvider);
+      },
+    );
+  }
+
+  void _showQuickActions(BuildContext context, Subscription subscription, SettingsProvider settingsProvider) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => Container(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              subscription.name,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '${settingsProvider.currencySymbol}${subscription.amount.toStringAsFixed(2)} • ${subscription.billingCycle}',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              subscription.getReminderMessage(),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: subscription.daysUntilNextBilling() < 0 ? Colors.red : Colors.orange,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      final subscriptionProvider = Provider.of<SubscriptionProvider>(context, listen: false);
+                      subscriptionProvider.markAsPaid(subscription.id!);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('Marked "${subscription.name}" as paid'),
+                          backgroundColor: Colors.green,
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.payment),
+                    label: const Text('Mark Paid'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const SubscriptionManagementScreen(),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.manage_accounts),
+                    label: const Text('Manage'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  IconData _getIconData(String iconName) {
+    switch (iconName.toLowerCase()) {
+      case 'netflix':
+        return Icons.movie;
+      case 'spotify':
+        return Icons.music_note;
+      case 'gym':
+        return Icons.fitness_center;
+      case 'phone':
+        return Icons.phone;
+      case 'internet':
+        return Icons.wifi;
+      case 'cloud':
+        return Icons.cloud;
+      case 'gaming':
+        return Icons.games;
+      case 'news':
+        return Icons.newspaper;
+      case 'food':
+        return Icons.restaurant;
+      case 'transport':
+        return Icons.directions_car;
+      default:
+        return Icons.subscriptions;
+    }
+  }
+}


### PR DESCRIPTION
## 🎯 What this PR adds

### New Features
- **Mark as Paid functionality**: Users can now mark subscriptions as paid for the current billing cycle
- **Visual payment indicators**: Green borders, check icons, and "PAID" badges for paid subscriptions
- **Enhanced subscription cards**: Show payment history and status with color coding

### UI/UX Enhancements
- Green visual indicators for paid subscriptions
- Payment history display in subscription details
- Conditional "Mark as Paid" vs "Already Paid" actions
- Fixed currency display consistency across preset system

## 🧪 Testing
- [x] Subscription payment marking works correctly
- [x] Visual indicators display properly
- [x] Database updates persist correctly
- [x] Currency displays correctly after switching
- [x] All existing features still work
